### PR TITLE
Update README for Intelligent Foods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-# Intelligent Foods API
+# Sunbasket API
 
-Intelligent Foods’s API empowers business partners to market and sell Sunbasket items via a comprehensive standards-based connection to Intelligent Foods’s backend catalog and fulfillment systems.
+Unfortunately Sunbasket no longer offers a pubic API. 
 
-For more information please see [Intelligent Foods API for business integration](https://intelligent-foods.github.io/partner-api/).
+If you are looking to re-sell Sunbasket meals on your website or in your app, we have partnered with a company called [Intelligent Foods].
+
+The [Intelligent Foods API] empowers business partners to market and sell Sunbasket items via a comprehensive standards-based connection to the Intelligent Foods' backend catalog and fulfillment systems.
+
+For more information please see [Intelligent Foods API] for business integration.
+
+[Intelligent Foods]: http://www.intelligentfoods.com
+[Intelligent Foods API]: https://intelligent-foods.github.io/partner-api/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Sunbasket API
+# [DEPRECATED] Sunbasket API
 
 Unfortunately Sunbasket no longer offers a pubic API. 
 
-If you are looking to re-sell Sunbasket meals on your website or in your app, we have partnered with a company called [Intelligent Foods].
+If you are looking to re-sell Sunbasket meals on your website or in your app, we have partnered with a company called [Intelligent Foods]. 
 
 The [Intelligent Foods API] empowers business partners to market and sell Sunbasket items via a comprehensive standards-based connection to the Intelligent Foods' backend catalog and fulfillment systems.
 


### PR DESCRIPTION
We need to decouple Sunbasket from Intelligent Foods. We want to let partners know that Sunbasket no longer offers an API and give the impression that Impossible Foods is a separate entity from Sunbasket.